### PR TITLE
replace NSException with NSError to enable catching when using form S…

### DIFF
--- a/QueueITLib/QueueITEngine.h
+++ b/QueueITLib/QueueITEngine.h
@@ -28,7 +28,7 @@ typedef enum {
                    language:(NSString*)language;
 
 -(void)setViewDelay:(int)delayInterval;
--(void)run;
+-(BOOL)run:(NSError *__autoreleasing *)error;
 -(void)raiseQueuePassed:(NSString*) queueitToken;
 -(BOOL)isUserInQueue;
 -(BOOL)isRequestInProgress;


### PR DESCRIPTION
Replace NSException with NSError to enable catching when using from Swift and prevent crashes in apps written in Swift.