### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "QueueITLibrary",
+    platforms: [
+        .iOS(.v11)
+    ],
+    products: [
+        .library(
+            name: "QueueITLibrary",
+            targets: ["QueueITLibrary"]),
+    ],
+    targets: [
+        .target(
+            name: "QueueITLibrary",
+            path: "QueueItLib/",
+            publicHeadersPath: ""
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ Then, run the following command:
 pod install
 ```
 
+## Swift Package Manager
+
+1. In Xcode, select File > Add Packages
+2. For the URL, paste in `https://github.com/queueit/ios-webui-sdk.git`
+3. Configure how you'd like to track changes, and add to your project
+4. Finally, click Add Package
+
 ## Usage
 
 We have a repository with a demo app [here](https://github.com/queueit/ios-demo-app "iOS demo app"), but you can get the basic idea of how to use the library in the following example.


### PR DESCRIPTION
This PR adds support for SPM. It works the same as the CocoaPods target, building from source directly.

## How to test

- Create a new project in Xcode
- File > Add Package
- Paste in the forks URL: `https://github.com/squarefrog/ios-webui-sdk`
- For Dependency Rule, choose Branch, and enter `spm` - we have to do this as the fork isn't tagged
- Click Add Package
- In your view controller, `import QueueITLibrary`, and perform any setup as required.

<img width="1089" alt="Screenshot 2022-08-26 at 14 11 01" src="https://user-images.githubusercontent.com/343450/186911118-f40b2f4f-5d85-49e3-b76d-62e45d1ed339.png">

Swift Package Manager doesn't require any additional support over what you already do for CocoaPods and manual framework creation. Just tag the release and off you go!