### PR TITLE
A fix for compilation error using Xcode 16.

### DIFF
--- a/QueueITLib.xcodeproj/project.pbxproj
+++ b/QueueITLib.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		1DE12F901B57E2ED00DD3BBE /* libQueueITLib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DE12F841B57E2ED00DD3BBE /* libQueueITLib.a */; };
 		1DE12FA71B57F0C000DD3BBE /* QueueService.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DE12FA61B57F0C000DD3BBE /* QueueService.m */; };
 		1DE12FAA1B57F14D00DD3BBE /* QueueService_NSURLConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DE12FA91B57F14D00DD3BBE /* QueueService_NSURLConnection.m */; };
-		1DE12FB01B57F24000DD3BBE /* QueueService_NSURLConnectionRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DE12FAF1B57F24000DD3BBE /* QueueService_NSURLConnectionRequest.m */; };
+		1DE12FB01B57F24000DD3BBE /* SDKQueueService_NSURLConnectionRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DE12FAF1B57F24000DD3BBE /* SDKQueueService_NSURLConnectionRequest.m */; };
 		1DE12FBC1B57F3A300DD3BBE /* QueueStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DE12FBB1B57F3A300DD3BBE /* QueueStatus.m */; };
 		1DE12FBF1B57F3DD00DD3BBE /* IOSUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DE12FBE1B57F3DD00DD3BBE /* IOSUtils.m */; };
 		1DE12FC21B57F42500DD3BBE /* QueueITEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DE12FC11B57F42500DD3BBE /* QueueITEngine.m */; };
@@ -64,8 +64,8 @@
 		1DE12FA61B57F0C000DD3BBE /* QueueService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QueueService.m; sourceTree = "<group>"; };
 		1DE12FA81B57F14D00DD3BBE /* QueueService_NSURLConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QueueService_NSURLConnection.h; sourceTree = "<group>"; };
 		1DE12FA91B57F14D00DD3BBE /* QueueService_NSURLConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QueueService_NSURLConnection.m; sourceTree = "<group>"; };
-		1DE12FAE1B57F23F00DD3BBE /* QueueService_NSURLConnectionRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QueueService_NSURLConnectionRequest.h; sourceTree = "<group>"; };
-		1DE12FAF1B57F24000DD3BBE /* QueueService_NSURLConnectionRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QueueService_NSURLConnectionRequest.m; sourceTree = "<group>"; };
+		1DE12FAE1B57F23F00DD3BBE /* SDKQueueService_NSURLConnectionRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDKQueueService_NSURLConnectionRequest.h; sourceTree = "<group>"; };
+		1DE12FAF1B57F24000DD3BBE /* SDKQueueService_NSURLConnectionRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDKQueueService_NSURLConnectionRequest.m; sourceTree = "<group>"; };
 		1DE12FBA1B57F3A300DD3BBE /* QueueStatus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QueueStatus.h; sourceTree = "<group>"; };
 		1DE12FBB1B57F3A300DD3BBE /* QueueStatus.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QueueStatus.m; sourceTree = "<group>"; };
 		1DE12FBD1B57F3DD00DD3BBE /* IOSUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IOSUtils.h; sourceTree = "<group>"; };
@@ -159,8 +159,8 @@
 				1DE12FA61B57F0C000DD3BBE /* QueueService.m */,
 				1DE12FA81B57F14D00DD3BBE /* QueueService_NSURLConnection.h */,
 				1DE12FA91B57F14D00DD3BBE /* QueueService_NSURLConnection.m */,
-				1DE12FAE1B57F23F00DD3BBE /* QueueService_NSURLConnectionRequest.h */,
-				1DE12FAF1B57F24000DD3BBE /* QueueService_NSURLConnectionRequest.m */,
+				1DE12FAE1B57F23F00DD3BBE /* SDKQueueService_NSURLConnectionRequest.h */,
+				1DE12FAF1B57F24000DD3BBE /* SDKQueueService_NSURLConnectionRequest.m */,
 				1DDF312C1C931DC00036E5EB /* QueueCache.h */,
 				1DDF312D1C931DC00036E5EB /* QueueCache.m */,
 			);
@@ -285,7 +285,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1DE12FB01B57F24000DD3BBE /* QueueService_NSURLConnectionRequest.m in Sources */,
+				1DE12FB01B57F24000DD3BBE /* SDKQueueService_NSURLConnectionRequest.m in Sources */,
 				1DE12FC21B57F42500DD3BBE /* QueueITEngine.m in Sources */,
 				1DCB83FD1BCE5375009B489A /* Reachability.m in Sources */,
 				1DE12FAA1B57F14D00DD3BBE /* QueueService_NSURLConnection.m in Sources */,

--- a/QueueITLib/QueueService_NSURLConnection.m
+++ b/QueueITLib/QueueService_NSURLConnection.m
@@ -1,5 +1,5 @@
 #import "QueueService_NSURLConnection.h"
-#import "QueueService_NSURLConnectionRequest.h"
+#import "SDKQueueService_NSURLConnectionRequest.h"
 
 @interface QueueService_NSURLConnection()<QueueService_NSURLConnectionRequestDelegate>
 @end
@@ -25,8 +25,8 @@
     [request addValue:@"application/json" forHTTPHeaderField:@"Accept"];
     [request addValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
     
-    QueueService_NSURLConnectionRequest *connectionRequest;
-    connectionRequest = [[QueueService_NSURLConnectionRequest alloc] initWithRequest:request
+    SDKQueueService_NSURLConnectionRequest *connectionRequest;
+    connectionRequest = [[SDKQueueService_NSURLConnectionRequest alloc] initWithRequest:request
                                                                   expectedStatusCode:expectedStatus
                                                                              success:success
                                                                              failure:failure
@@ -39,7 +39,7 @@
 
 #pragma mark - NSURLConnectionRequestDelegate
 
-- (void)requestDidComplete:(QueueService_NSURLConnectionRequest *)request
+- (void)requestDidComplete:(SDKQueueService_NSURLConnectionRequest *)request
 {
 }
 

--- a/QueueITLib/QueueService_NSURLConnection.m
+++ b/QueueITLib/QueueService_NSURLConnection.m
@@ -1,7 +1,7 @@
 #import "QueueService_NSURLConnection.h"
 #import "SDKQueueService_NSURLConnectionRequest.h"
 
-@interface QueueService_NSURLConnection()<QueueService_NSURLConnectionRequestDelegate>
+@interface QueueService_NSURLConnection()<SDKQueueService_NSURLConnectionRequestDelegate>
 @end
 
 

--- a/QueueITLib/SDKQueueService_NSURLConnectionRequest.h
+++ b/QueueITLib/SDKQueueService_NSURLConnectionRequest.h
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
 #import "QueueService.h"
 
-@protocol QueueService_NSURLConnectionRequestDelegate;
+@protocol SDKQueueService_NSURLConnectionRequestDelegate;
 
 @interface SDKQueueService_NSURLConnectionRequest : NSObject<NSURLConnectionDelegate, NSURLConnectionDataDelegate>
 
@@ -11,10 +11,10 @@
              expectedStatusCode:(NSInteger)statusCode
                         success:(QueueServiceSuccess)success
                         failure:(QueueServiceFailure)failure
-                       delegate:(id<QueueService_NSURLConnectionRequestDelegate>)delegate;
+                       delegate:(id<SDKQueueService_NSURLConnectionRequestDelegate>)delegate;
 
 @end
 
-@protocol QueueService_NSURLConnectionRequestDelegate <NSObject>
+@protocol SDKQueueService_NSURLConnectionRequestDelegate <NSObject>
 - (void)requestDidComplete:(SDKQueueService_NSURLConnectionRequest *)request;
 @end

--- a/QueueITLib/SDKQueueService_NSURLConnectionRequest.h
+++ b/QueueITLib/SDKQueueService_NSURLConnectionRequest.h
@@ -3,7 +3,7 @@
 
 @protocol QueueService_NSURLConnectionRequestDelegate;
 
-@interface QueueService_NSURLConnectionRequest : NSObject<NSURLConnectionDelegate, NSURLConnectionDataDelegate>
+@interface SDKQueueService_NSURLConnectionRequest : NSObject<NSURLConnectionDelegate, NSURLConnectionDataDelegate>
 
 - (NSString *)uniqueIdentifier;
 
@@ -16,5 +16,5 @@
 @end
 
 @protocol QueueService_NSURLConnectionRequestDelegate <NSObject>
-- (void)requestDidComplete:(QueueService_NSURLConnectionRequest *)request;
+- (void)requestDidComplete:(SDKQueueService_NSURLConnectionRequest *)request;
 @end

--- a/QueueITLib/SDKQueueService_NSURLConnectionRequest.m
+++ b/QueueITLib/SDKQueueService_NSURLConnectionRequest.m
@@ -1,7 +1,7 @@
-#import "QueueService_NSURLConnectionRequest.h"
+#import "SDKQueueService_NSURLConnectionRequest.h"
 
 
-@interface QueueService_NSURLConnectionRequest()
+@interface SDKQueueService_NSURLConnectionRequest()
 
 @property (nonatomic, strong) NSURLConnection *connection;
 @property (nonatomic, strong) NSURLRequest *request;
@@ -16,7 +16,7 @@
 
 @end
 
-@implementation QueueService_NSURLConnectionRequest
+@implementation SDKQueueService_NSURLConnectionRequest
 
 - (instancetype)initWithRequest:(NSURLRequest *)request
              expectedStatusCode:(NSInteger)statusCode

--- a/QueueITLib/SDKQueueService_NSURLConnectionRequest.m
+++ b/QueueITLib/SDKQueueService_NSURLConnectionRequest.m
@@ -9,7 +9,7 @@
 @property (nonatomic, strong) NSMutableData *data;
 @property (nonatomic, copy) QueueServiceSuccess successCallback;
 @property (nonatomic, copy) QueueServiceFailure failureCallback;
-@property (nonatomic, weak) id<QueueService_NSURLConnectionRequestDelegate> delegate;
+@property (nonatomic, weak) id<SDKQueueService_NSURLConnectionRequestDelegate> delegate;
 @property (nonatomic, strong) NSString *uniqueIdentifier;
 @property (nonatomic, assign) NSInteger expectedStatusCode;
 @property (nonatomic, assign) NSInteger actualStatusCode;
@@ -22,7 +22,7 @@
              expectedStatusCode:(NSInteger)statusCode
                         success:(QueueServiceSuccess)success
                         failure:(QueueServiceFailure)failure
-                       delegate:(id<QueueService_NSURLConnectionRequestDelegate>)delegate
+                       delegate:(id<SDKQueueService_NSURLConnectionRequestDelegate>)delegate
 {
     if ((self = [super init])) {
         self.request = request;


### PR DESCRIPTION
QueueService_NSURLConnectionRequest protocol was renamed in order not to produce a compilation error using Xcode 16.